### PR TITLE
chore: Cancel clean biarch dirs for obs init buildsystem

### DIFF
--- a/debian/usrmerge.postinst
+++ b/debian/usrmerge.postinst
@@ -83,10 +83,9 @@ case "$1" in
 	  exit 1
 	else
 	  maybe_convert "$@" || { echo "E: usrmerge failed." >&2; exit 1; }
-	  cleanup_biarch_dirs
+	  #cleanup_biarch_dirs
 	fi
     ;;
 esac
 
 #DEBHELPER#
-


### PR DESCRIPTION
obs初始化构建环境时并未完整执行安装过程,而usrmerge因为obs计算依赖关系问题的问题执行的安装时机不可控, 导致dpkg-query的查询结果并不准确,清理掉一些不该清除的库目录,因此现阶段取消这个步骤,等后续仓库 中的软件包组安装逐渐被控制排除这些目录(lib64/lib32/libo32/libx32)后再开启。